### PR TITLE
fix(lwc): adjust re-rendering of multi select combobox options

### DIFF
--- a/force-app/main/default/lwc/multiSelectCombobox/multiSelectCombobox.js
+++ b/force-app/main/default/lwc/multiSelectCombobox/multiSelectCombobox.js
@@ -124,7 +124,7 @@ export default class MultiSelectCombobox extends LightningElement {
 
   handleClick() {
     // initialize picklist options on first click to make them editable
-    if (this.isLoaded === false) {
+    if (this.isLoaded === false || (this.currentOptions?.length !== this.options?.length)) {
       this.currentOptions = JSON.parse(JSON.stringify(this.options));
       this.isLoaded = true;
     }


### PR DESCRIPTION
The multiselect combobox wasn't working when I dynamically updated the options array in my LWC. It used to show only the default values with which it was initialised. I've made a very small change in the click handler to check if the options have changed so the combobox options work correctly with newer modified options. 

Thanks !